### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - export MAVEN_SKIP_RC=true
 
 matrix:
+  fast_finish: true
   include:
     - env: JDK='Oracle JDK 8'
       jdk: oraclejdk8
@@ -49,3 +50,7 @@ script:
 after_script:
   - mysql -e 'DROP DATABASE test;'
 
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
